### PR TITLE
Reaction ID search fix

### DIFF
--- a/src/modelseed/generate_reactions.py
+++ b/src/modelseed/generate_reactions.py
@@ -50,6 +50,7 @@ def gen_reaction(row, headers):
         reaction[headers[idx]] = col
     if "_key" not in reaction:
         return
+    reaction['id'] = reaction['_key']
     yield reaction
 
 


### PR DESCRIPTION
Add the id separate from the _key so it can be searched.