### PR TITLE
Don't nest pipenv calls in GHA

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -43,7 +43,7 @@ jobs:
         export ARANGO=`pwd`/arangodb3-linux-$ARANGODB_VER/bin/arangodb
         export ARANGOD=`pwd`/arangodb3-linux-$ARANGODB_VER/usr/sbin/arangod
         $ARANGO start --server.arangod=$ARANGOD --starter.mode single --starter.data-dir ./arangodata
-        PYTHONPATH=$(pwd):$(pwd)/src pipenv run make test
+        make test
         $ARANGO stop
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3


### PR DESCRIPTION
No need for setting the path or wrapping `make test` in `pipenv run`.
The path is set by the shell script and `pipenv run` is called in the `Makefile`.

Not really sure if it makes sense to separate the makefile and the script
TBH...