### PR TITLE
Update NCBI download helper

### DIFF
--- a/relation_engine/taxa/ncbi/helper_scripts/ncbi_taxa_download_archive.py
+++ b/relation_engine/taxa/ncbi/helper_scripts/ncbi_taxa_download_archive.py
@@ -3,10 +3,10 @@
 # Downloads all the NCBI tax dumps from the ftp site. Does not download the new_taxdump* archives.
 # use -h for help.
 
+# Tested manually. Be sure to retest if you make changes.
+
 from ftplib import FTP
-import zipfile
 import pathlib
-import os
 import argparse
 NCBI_HOST = 'ftp.ncbi.nih.gov'
 NCBI_TAX_DIR = '/pub/taxonomy/taxdump_archive/'
@@ -22,17 +22,14 @@ def parseargs():
     return parser.parse_args()
 
 
-def download_and_unzip(ftp, directory, filename):
-    zf = os.path.join(directory, filename)
+def download_if_missing(ftp, directory, filename):
+    zf = pathlib.Path(directory) / filename
+    if (zf.exists()):
+        print(f'Skipping {zf}, file already exists')
+        return
     with open(zf, 'wb') as f:
+        print(f'Downloading {zf}')
         ftp.retrbinary(f'RETR {filename}', lambda block: f.write(block))
-
-    dirname = os.path.splitext(filename)[0]
-    pathlib.Path(os.path.join(directory, dirname)).mkdir(parents=True, exist_ok=True)
-    # pyzip is apparently really slow
-    with zipfile.ZipFile(zf) as zipread:
-        # should really check for malicious paths here but we assume NCBI are nice guys
-        zipread.extractall(dirname)
 
 
 def main():
@@ -44,7 +41,7 @@ def main():
         ftp.cwd(NCBI_TAX_DIR)
         for f in ftp.mlsd(facts=['size']):
             if f[0].startswith(TAXDUMP_PREFIX):
-                download_and_unzip(ftp, a.dir, f[0])
+                download_if_missing(ftp, a.dir, f[0])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* Don't unzip. Each file is ~50MB zipped but ~400MB unzipped and there's 8 years of monthly dumps. That's a lot of space - let the user decide (there's plenty of separate zip programs out there), or better yet update the loader to read zip files.
* Skip `taxdmp` files that already exist rather than overwriting them with the same data.
* Give the user some feedback as to what's going on.

Tested manually. Since it's just a helper script, it's self contained, it's very simple, and actual tests would be really slow manual testing will do.

Closes #20 